### PR TITLE
fixing the format of the resources table in the bottom of the ERD.md file.  space required immediately above the table in order for it to format properly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore files from IDEs, i.e. RubyMine for KZ
+.idea/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/kingmaker.iml
+++ b/.idea/kingmaker.iml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="RUBY_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="RailsFacetType" name="Ruby on Rails">
+      <configuration>
+        <RAILS_FACET_CONFIG_ID NAME="RAILS_FACET_SUPPORT_REMOVED" VALUE="false" />
+        <RAILS_FACET_CONFIG_ID NAME="RAILS_TESTS_SOURCES_PATCHED" VALUE="true" />
+        <RAILS_FACET_CONFIG_ID NAME="RAILS_FACET_APPLICATION_ROOT" VALUE="$MODULE_DIR$" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="ModuleRunConfigurationManager">
+    <shared />
+  </component>
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/features" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/.bundle" />
+      <excludeFolder url="file://$MODULE_DIR$/components" />
+      <excludeFolder url="file://$MODULE_DIR$/log" />
+      <excludeFolder url="file://$MODULE_DIR$/public/packs" />
+      <excludeFolder url="file://$MODULE_DIR$/public/system" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/bundle" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/cache" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="PROVIDED" name="bindex (v0.8.1, ruby-3.2.3-p157) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="bundler (v2.6.7, ruby-3.2.3-p157) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="globalid (v1.2.1, ruby-3.2.3-p157) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="mini_mime (v1.1.5, ruby-3.2.3-p157) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="net-pop (v0.1.2, ruby-3.2.3-p157) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="tzinfo (v2.0.6, ruby-3.2.3-p157) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="websocket-extensions (v0.1.5, ruby-3.2.3-p157) [gem]" level="application" />
+  </component>
+  <component name="RModuleSettingsStorage">
+    <LOAD_PATH number="0" />
+    <I18N_FOLDERS number="1" string0="$MODULE_DIR$/config/locales" />
+  </component>
+  <component name="RailsPaths" isManagedAutomatically="true">
+    <entry key="app">
+      <value>file://$MODULE_DIR$/app</value>
+    </entry>
+    <entry key="app/assets">
+      <value>file://$MODULE_DIR$/app/assets</value>
+    </entry>
+    <entry key="app/channels">
+      <value>file://$MODULE_DIR$/app/channels</value>
+    </entry>
+    <entry key="app/controllers">
+      <value>file://$MODULE_DIR$/app/controllers</value>
+    </entry>
+    <entry key="app/helpers">
+      <value>file://$MODULE_DIR$/app/helpers</value>
+    </entry>
+    <entry key="app/mailers">
+      <value>file://$MODULE_DIR$/app/mailers</value>
+    </entry>
+    <entry key="app/models">
+      <value>file://$MODULE_DIR$/app/models</value>
+    </entry>
+    <entry key="app/views">
+      <value>file://$MODULE_DIR$/app/views</value>
+    </entry>
+    <entry key="config">
+      <value>file://$MODULE_DIR$/config</value>
+    </entry>
+    <entry key="config/cable">
+      <value>file://$MODULE_DIR$/config/cable.yml</value>
+    </entry>
+    <entry key="config/database">
+      <value>file://$MODULE_DIR$/config/database.yml</value>
+    </entry>
+    <entry key="config/environment">
+      <value>file://$MODULE_DIR$/config/environment.rb</value>
+    </entry>
+    <entry key="config/environments">
+      <value>file://$MODULE_DIR$/config/environments</value>
+    </entry>
+    <entry key="config/initializers">
+      <value>file://$MODULE_DIR$/config/initializers</value>
+    </entry>
+    <entry key="config/locales">
+      <value>file://$MODULE_DIR$/config/locales</value>
+    </entry>
+    <entry key="config/routes">
+      <value>file://$MODULE_DIR$/config/routes</value>
+    </entry>
+    <entry key="config/routes.rb">
+      <value>file://$MODULE_DIR$/config/routes.rb</value>
+    </entry>
+    <entry key="config/secrets">
+      <value>file://$MODULE_DIR$/config</value>
+    </entry>
+    <entry key="db">
+      <value>file://$MODULE_DIR$/db</value>
+    </entry>
+    <entry key="db/migrate">
+      <value>file://$MODULE_DIR$/db/migrate</value>
+    </entry>
+    <entry key="db/seeds.rb">
+      <value>file://$MODULE_DIR$/db/seeds.rb</value>
+    </entry>
+    <entry key="lib">
+      <value>file://$MODULE_DIR$/lib</value>
+    </entry>
+    <entry key="lib/assets">
+      <value>file://$MODULE_DIR$/lib/assets</value>
+    </entry>
+    <entry key="lib/tasks">
+      <value>file://$MODULE_DIR$/lib/tasks</value>
+    </entry>
+    <entry key="lib/templates">
+      <value>file://$MODULE_DIR$/lib/templates</value>
+    </entry>
+    <entry key="log">
+      <value>file://$MODULE_DIR$/log/development.log</value>
+    </entry>
+    <entry key="public">
+      <value>file://$MODULE_DIR$/public</value>
+    </entry>
+    <entry key="public/javascripts">
+      <value>file://$MODULE_DIR$/public/javascripts</value>
+    </entry>
+    <entry key="public/stylesheets">
+      <value>file://$MODULE_DIR$/public/stylesheets</value>
+    </entry>
+    <entry key="tmp">
+      <value>file://$MODULE_DIR$/tmp</value>
+    </entry>
+    <entry key="vendor">
+      <value>file://$MODULE_DIR$/vendor</value>
+    </entry>
+    <entry key="vendor/assets">
+      <value>file://$MODULE_DIR$/vendor/assets</value>
+    </entry>
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="ruby-3.2.3-p157" project-jdk-type="RUBY_SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/kingmaker.iml" filepath="$PROJECT_DIR$/.idea/kingmaker.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "kamal", require: false
 gem "thruster", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-  gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.2"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/app/controllers/hexes_controller.rb
+++ b/app/controllers/hexes_controller.rb
@@ -3,9 +3,9 @@ class HexesController < ApplicationController
 
   def update
     if @hex.update(hex_params)
-      redirect_to @map, notice: 'Hex region updated successfully.'
+      redirect_to @map, notice: "Hex region updated successfully."
     else
-      redirect_to @map, alert: 'Failed to update hex region.'
+      redirect_to @map, alert: "Failed to update hex region."
     end
   end
 

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -61,7 +61,7 @@ class MapsController < ApplicationController
     @map.hexes.each do |hex|
       hex.update(label: hex.default_label)
     end
-    
+
     redirect_to @map, notice: "All hex labels updated to default."
   end
 

--- a/app/controllers/regions_controller.rb
+++ b/app/controllers/regions_controller.rb
@@ -3,11 +3,11 @@ class RegionsController < ApplicationController
 
   def create
     @region = @map.regions.build(region_params)
-    
+
     if @region.save
-      redirect_to @map, notice: 'Region was successfully created.'
+      redirect_to @map, notice: "Region was successfully created."
     else
-      redirect_to @map, alert: 'Failed to create region.'
+      redirect_to @map, alert: "Failed to create region."
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
     user = User.new(params.require(:user).permit(:email_address, :password, :password_confirmation))
     if user.save
       start_new_session_for user
-      redirect_to maps_path, notice: 'User was successfully created.'
+      redirect_to maps_path, notice: "User was successfully created."
     else
       render :new
     end

--- a/app/models/hex.rb
+++ b/app/models/hex.rb
@@ -3,6 +3,7 @@ class Hex < ApplicationRecord
   belongs_to :region, optional: true
   has_many :hex_resources, dependent: :destroy
   has_many :resources, through: :hex_resources
+  has_many :notes, dependent: :destroy
 
   def coordinates
     "#{x_coordinate}, #{y_coordinate}"

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -5,7 +5,7 @@ class Map < ApplicationRecord
 
   def create_initial_hexes
     return if hexes.exists?
-    # Create a grid of hexes for the map    
+    # Create a grid of hexes for the map
     (0..columns).each do |x|
       (0..rows).each do |y|
         hexes.create(x_coordinate: x, y_coordinate: y, label: "Hex #{x},#{y}", reconnoitered: false, claimed: false, visible: true)

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -2,6 +2,10 @@ class Map < ApplicationRecord
   has_one_attached :image
   has_many :hexes, dependent: :destroy
   has_many :regions, dependent: :destroy
+  has_many :notes, dependent: :destroy
+  has_many :kingdoms, dependent: :destroy
+  has_many :player_maps, dependent: :destroy
+  has_many :hex_notes, through: :hexes, source: :notes
 
   def create_initial_hexes
     return if hexes.exists?

--- a/app/views/maps/_map.html.erb
+++ b/app/views/maps/_map.html.erb
@@ -25,7 +25,12 @@
     <%= form.submit "Add Region" %>
   <% end %>
 
-  <%= image_tag map.image.representation(resize_to_limit: [500, 500]) %>
+  <% if map.image.attached? %>
+    <%= image_tag map.image.representation(resize_to_limit: [500, 500]) %>
+  <% else %>
+    <!-- Show placeholder or nothing -->
+    <div class="no-image-placeholder">No image available</div>
+  <% end %>
  
   <% map.hexes.each do |hex| %>
     <%= render 'hexes/hex', hex: hex %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,14 @@
 Rails.application.routes.draw do
   resources :maps do
-    resources :regions, only: [:create]
-    resources :hexes, only: [:update]
+    resources :regions, only: [ :create ]
+    resources :hexes, only: [ :update ]
     member do
       patch :update_hex_labels
     end
   end
   resource :session
   resources :passwords, param: :token
-  resources :users, only: [:new, :create]
+  resources :users, only: [ :new, :create ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,5 +20,5 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "maps#index"
 end

--- a/erd.md
+++ b/erd.md
@@ -77,7 +77,9 @@ classDiagram
 
 
 resources
-| id | name | ore_generation | food_generation |
-|----|------|----------------|-----------------|
-| 1  | mine | 1              | 0               |
-| 2  | farm | 0              | 1               |
+
+| id | name        | ore_generation | food_generation | lumber_generation |
+|----|-------------|----------------|-----------------|-------------------|
+| 1  | mine        | 1              | 0               |                   |
+| 2  | farm        | 0              | 1               |                   |
+| 3  | lumber mill | 0              | 0               | 1                 |

--- a/test/controllers/maps_controller_test.rb
+++ b/test/controllers/maps_controller_test.rb
@@ -3,6 +3,13 @@ require "test_helper"
 class MapsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @map = maps(:one)
+    @user = users(:one)
+
+    post session_path, params: {
+      email_address: @user.email_address,
+      password: 'password'
+    }
+
   end
 
   test "should get index" do

--- a/test/controllers/maps_controller_test.rb
+++ b/test/controllers/maps_controller_test.rb
@@ -7,9 +7,8 @@ class MapsControllerTest < ActionDispatch::IntegrationTest
 
     post session_path, params: {
       email_address: @user.email_address,
-      password: 'password'
+      password: "password"
     }
-
   end
 
   test "should get index" do

--- a/test/fixtures/hexes.yml
+++ b/test/fixtures/hexes.yml
@@ -4,7 +4,7 @@ one:
   x_coordinate: 1
   y_coordinate: 1
   label: MyString
-  reconreconnoitered: false
+  reconnoitered: false
   claimed: false
   map: one
 
@@ -12,6 +12,6 @@ two:
   x_coordinate: 1
   y_coordinate: 1
   label: MyString
-  reconreconnoitered: false
+  reconnoitered: false
   claimed: false
   map: two

--- a/test/fixtures/maps.yml
+++ b/test/fixtures/maps.yml
@@ -1,7 +1,11 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  name: MyString
+  name: "Map test 1"
+  columns: 12
+  rows: 6
 
 two:
-  name: MyString
+  name: "Map test 2"
+  columns: 9
+  rows: 3

--- a/test/fixtures/sessions.yml
+++ b/test/fixtures/sessions.yml
@@ -1,0 +1,9 @@
+one:
+  user: one
+  user_agent: "Test Agent 1"
+  ip_address: "127.0.0.1"
+
+two:
+  user: two
+  user_agent: "Test Agent 2"
+  ip_address: "127.0.0.1"


### PR DESCRIPTION
The fix may not be noticeable in github itself, but by adding a space directly above the table at the bottom of the erd.md file, the preview panel will properly render it, and the md editor should show you a proper table editing UI for easier table editing.