### PR TITLE
Map detail view overhaul!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@
 !/app/assets/builds/.keep
 
 /node_modules
+
+# Ignore PNG maps generated while testing
+/public/maps

--- a/.idea/kingmaker.iml
+++ b/.idea/kingmaker.iml
@@ -55,6 +55,7 @@
     <orderEntry type="library" scope="PROVIDED" name="builder (v3.3.0, rbenv: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="bundler (v2.6.7, rbenv: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="capybara (v3.40.0, rbenv: 3.4.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="chunky_png (v1.4.0, rbenv: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="concurrent-ruby (v1.3.5, rbenv: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="connection_pool (v2.5.3, rbenv: 3.4.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="crass (v1.0.6, rbenv: 3.4.4) [gem]" level="application" />

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,10 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"
 
+# ChunkyPNG for processing the map and hexes into single images:
+gem "chunky_png"
+gem "mini_magick"
+
 # Typescript
 gem "jsbundling-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chunky_png (1.4.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -387,12 +388,14 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  chunky_png
   debug
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
   jsbundling-rails
   kamal
+  mini_magick
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.2)

--- a/app/controllers/hexes_controller.rb
+++ b/app/controllers/hexes_controller.rb
@@ -1,5 +1,6 @@
 class HexesController < ApplicationController
-  before_action :set_map_and_hex
+  before_action :set_map_and_hex, except: [ :bulk_create ]
+  before_action :set_map, only: [ :bulk_create ]
 
   def update
     if @hex.update(hex_params)
@@ -9,11 +10,38 @@ class HexesController < ApplicationController
     end
   end
 
+  def bulk_create
+    hex_params = params[:hexes]
+    created_hexes = []
+    hex_params.each do |hex_data|
+      hex = @map.hexes.create!(
+        x_coordinate: hex_data[:x_coordinate],
+        y_coordinate: hex_data[:y_coordinate],
+        reconnoitered: hex_data[:reconnoitered],
+        claimed: hex_data[:claimed],
+        visible: hex_data[:visible],
+        region_id: hex_data[:region_id]
+      )
+      created_hexes << hex
+    end
+    render json: {
+      success: true,
+      message: "#{created_hexes.count} hexes created successfully",
+      hexes: created_hexes
+    }
+  rescue => e
+    render json: { success: false, error: e.message }, status: 422
+  end
+
   private
 
   def set_map_and_hex
     @map = Map.find(params[:map_id])
     @hex = @map.hexes.find(params[:id])
+  end
+
+  def set_map
+    @map = Map.find(params[:map_id])
   end
 
   def hex_params

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -8,6 +8,7 @@ class MapsController < ApplicationController
 
   # GET /maps/1 or /maps/1.json
   def show
+    @map = Map.find(params[:id])
   end
 
   # GET /maps/new

--- a/app/javascript/controllers/hex_controller.js
+++ b/app/javascript/controllers/hex_controller.js
@@ -1,0 +1,110 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static targets = ["map"]
+    static values = {
+        mapId: Number,
+        hexCols: Number,
+        hexRows: Number
+    }
+
+    generateHexes() {
+        const hexData = [];
+
+        // Generate hex coordinates
+        for (let col = 0; col < this.hexColsValue; col++) {
+            for (let row = 0; row < this.hexRowsValue; row++) {
+                console.log("hex data:", col, row, this.mapIdValue)
+                hexData.push({
+                    map_id: this.mapIdValue,
+                    x_coordinate: col,
+                    y_coordinate: row,
+                    reconnoitered: false,
+                    claimed: false,
+                    visible: true,
+                    region_id: null,
+                });
+            }
+        }
+
+        // Send to Rails backend
+        this.createHexesInDatabase(hexData);
+    }
+
+    async createHexesInDatabase(hexData) {
+        try {
+            console.log(hexData)
+            const response = await fetch(`/maps/${this.mapIdValue}/hexes/bulk_create`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': document.querySelector('[name="csrf-token"]').getAttribute('content')
+                },
+                body: JSON.stringify({ hexes: hexData })
+            });
+
+            if (response.ok) {
+                const result = await response.json();
+                console.log('Hexes created successfully:', result);
+                // Optionally refresh the page or update the UI
+                location.reload();
+            } else {
+                console.error('Failed to create hexes');
+            }
+        } catch (error) {
+            console.error('Error creating hexes:', error);
+        }
+    }
+
+    toggleHexFlyout(){
+        if(document.getElementById("hexes-edit-button").textContent === "Manage Hexes"){
+            this.enableHexFlyout()
+        } else {
+            this.disableHexFlyout()
+        }
+    }
+
+    enableHexFlyout(){
+        document.getElementById("edit-map-button").classList.add("hidden")
+        document.getElementById("manage-regions-button").classList.add("hidden")
+        document.getElementById("hexes-edit-button").textContent = "Go Back"
+        document.getElementById("region-container").classList.add("hidden")
+        document.getElementById("hex-flyout-section").classList.remove("hidden")
+    }
+
+    disableHexFlyout(){
+        document.getElementById("edit-map-button").classList.remove("hidden")
+        document.getElementById("manage-regions-button").classList.remove("hidden")
+        document.getElementById("hexes-edit-button").textContent = "Manage Hexes"
+        document.getElementById("region-container").classList.remove("hidden")
+        document.getElementById("hex-flyout-section").classList.add("hidden")
+    }
+
+    enableHexEditPane(){
+        document.getElementById("map-info").classList.add("hidden")
+        document.getElementById("controls").classList.remove("hidden")
+        document.getElementById("hex-controls").classList.remove("hidden")
+        document.getElementById("region-controls").classList.add("hidden")
+
+        // Switch to hex editing view
+        document.getElementById("normal-map-view").classList.add("hidden")
+        document.getElementById("hex-edit-view").classList.remove("hidden")
+    }
+
+    flipHexStyle(){
+        const flipHexButton = document.getElementById("hex-style-switch")
+        if(flipHexButton.textContent.charAt(0) === "⬢"){
+            flipHexButton.textContent = "⬣"
+        } else {
+            flipHexButton.textContent = "⬢"
+        }
+
+        this.dispatch('hexStyleChange', {
+          detail: {
+            hexStyle: flipHexButton.textContent
+          },
+          bubbles: true
+        })
+    }
+
+}

--- a/app/javascript/controllers/hex_editor_controller.js
+++ b/app/javascript/controllers/hex_editor_controller.js
@@ -1,0 +1,85 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["hexOverlay"]
+  static values = {
+    hexes: Array,
+    hexScaleX: Number,
+    hexScaleY: Number,
+    offsetX: Number,
+    offsetY: Number
+  }
+
+
+  connect() {
+    this.element.addEventListener('map-play:transformed', this.updateHexTransform.bind(this));
+    document.addEventListener('hexes:hexStyleChange', (event) => this.drawHexes(event.detail.hexStyle));
+    this.drawHexes(document.getElementById("hex-style-switch").textContent.charAt(0));
+  }
+
+  // Draw all hexes on the SVG overlay
+  drawHexes(hexStyle) {
+    if (!this.hasHexOverlayTarget) return;
+
+    const svg = this.hexOverlayTarget;
+    svg.innerHTML = '';
+
+    this.hexesValue.forEach(hex => {
+      this.drawHex(svg, hex, hexStyle);
+    });
+  }
+
+  drawHex(svg, hex, currentHexStyle) {
+    // Use the Value accessors correctly
+    const centerX = (this.hexScaleXValue * 40 * hex.x_coordinate) + this.offsetXValue + (20 * this.hexScaleXValue);
+    const centerY = (this.hexScaleYValue * 40 * hex.y_coordinate) + this.offsetYValue + (20 * this.hexScaleYValue);
+    const radius = 18;
+
+    const points = [];
+
+    // Use the currentHexStyle passed from the event
+    if (currentHexStyle === "⬣") { // Flat-top hexagon
+      for (let i = 0; i < 6; i++) {
+        const angle = (Math.PI / 3) * i;
+        const x = centerX + radius * Math.cos(angle);
+        const y = centerY + radius * Math.sin(angle);
+        points.push(`${x},${y}`);
+      }
+    } else { // Pointy-top hexagon (⬢)
+      for (let i = 0; i < 6; i++) {
+        const angle = (Math.PI / 3) * i - (Math.PI / 2);
+        const x = centerX + radius * Math.cos(angle);
+        const y = centerY + radius * Math.sin(angle);
+        points.push(`${x},${y}`);
+      }
+    }
+
+    const polygon = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
+    polygon.setAttribute('points', points.join(' '));
+    polygon.setAttribute('fill', 'transparent');
+    polygon.setAttribute('stroke', this.getHexColor(hex));
+    polygon.setAttribute('stroke-width', '2');
+    polygon.setAttribute('data-hex-id', hex.id);
+
+    svg.appendChild(polygon);
+  }
+
+  getHexColor(hex) {
+    if (!hex.region_id) {
+      return '#808080'
+    } else {
+      const colors = ['#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#FF00FF', '#00FFFF']
+      return colors[hex.region_id % 6]
+    }
+  }
+
+  // Apply the same transform to the hex overlay that's applied to the map image
+  updateHexTransform(event) {
+    if (this.hasHexOverlayTarget) {
+      // Apply the exact same transform string that's applied to the map image
+      this.hexOverlayTarget.style.transform = event.detail.transform
+    }
+  }
+
+
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,19 +1,23 @@
 // Import and register all your controllers from the importmap via controllers/**/*_controller
-import { Application } from "@hotwired/stimulus";
-const application = Application.start();
+import { Application } from "@hotwired/stimulus"
+const application = Application.start()
 
-/**
- * To register a new controller, follow this naming convention:
- * import ChooseAnyName from "./path/to/controller.js"
- * application.register("controller-name-kebab-case", ChooseAnyName);
- *
- * Note that the "controller-name-kebab-case" must match your controller javaclass name,
- * but without the word "controller" at the end, and in kebab-case instead of snake_case.
- */
-import TabsController from "./tabs_controller";
-application.register("tabs", TabsController);
+import TabsController from "./tabs_controller"
+application.register("tabs", TabsController)
 
-import MapController from "./maps_controller";
-application.register("maps", MapController);
+import MapController from "./maps_controller"
+application.register("maps", MapController)
+
+import MapPlayController from "./map_play_controller"
+application.register("map-play", MapPlayController)
+
+import HexController from "./hex_controller"
+application.register("hexes", HexController)
+
+import RegionController from "./region_controller"
+application.register("regions", RegionController)
+
+import HexEditorController from "./hex_editor_controller"
+application.register("hex-editor", HexEditorController)
 
 export { application }

--- a/app/javascript/controllers/map_play_controller.js
+++ b/app/javascript/controllers/map_play_controller.js
@@ -1,0 +1,125 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["container", "normalImage", "editImage"]
+  static values = { mapId: Number }
+
+  connect() {
+    this.isDragging = false
+    this.startX = 0
+    this.startY = 0
+    this.currentX = 0
+    this.currentY = 0
+    this.scale = 1
+    this.minScale = 0.5
+    this.maxScale = 3
+    this.zoomRate = 0.2
+
+    // Bind event listeners
+    this.boundMouseMove = this.handleMouseMove.bind(this)
+    this.boundMouseUp = this.handleMouseUp.bind(this)
+
+    // Prevent context menu on right click
+    this.containerTarget.addEventListener('contextmenu', (e) => e.preventDefault())
+
+    // Initialize image position
+    this.updateTransform()
+  }
+
+  disconnect() {
+    document.removeEventListener('mousemove', this.boundMouseMove)
+    document.removeEventListener('mouseup', this.boundMouseUp)
+  }
+
+  startDrag(event) {
+    event.preventDefault()
+
+    this.isDragging = true
+    this.startX = event.clientX - this.currentX
+    this.startY = event.clientY - this.currentY
+
+    this.containerTarget.style.cursor = 'grabbing'
+
+    document.addEventListener('mousemove', this.boundMouseMove)
+    document.addEventListener('mouseup', this.boundMouseUp)
+  }
+
+  handleMouseMove(event) {
+    if (!this.isDragging) return
+
+    event.preventDefault()
+
+    this.currentX = event.clientX - this.startX
+    this.currentY = event.clientY - this.startY
+
+    this.updateTransform()
+  }
+
+  handleMouseUp(event) {
+    if (!this.isDragging) return
+
+    this.isDragging = false
+    this.containerTarget.style.cursor = 'grab'
+
+    document.removeEventListener('mousemove', this.boundMouseMove)
+    document.removeEventListener('mouseup', this.boundMouseUp)
+  }
+
+  handleZoom(event) {
+    event.preventDefault()
+
+    const delta = event.deltaY > 0 ? -this.zoomRate : this.zoomRate
+    const newScale = Math.max(this.minScale, Math.min(this.maxScale, this.scale + delta))
+
+    if (newScale !== this.scale) {
+      // Get mouse position relative to container
+      const rect = this.containerTarget.getBoundingClientRect()
+      const mouseX = event.clientX - rect.left - (rect.width / 2)
+      const mouseY = event.clientY - rect.top - (rect.height / 2)
+
+      // Calculate the point on the image that the mouse is currently over
+      const imagePointX = (mouseX - this.currentX) / this.scale
+      const imagePointY = (mouseY - this.currentY) / this.scale
+
+      // Update scale
+      this.scale = newScale
+
+      // Calculate new position so the same image point stays under the mouse
+      this.currentX = mouseX - (imagePointX * this.scale)
+      this.currentY = mouseY - (imagePointY * this.scale)
+
+      this.updateTransform()
+    }
+  }
+
+  updateTransform() {
+    const transform = `translate(${this.currentX}px, ${this.currentY}px) scale(${this.scale})`
+
+    // Apply transform to whichever image is currently visible
+    if (this.hasNormalImageTarget && !document.getElementById("normal-map-view").classList.contains("hidden")) {
+      this.normalImageTarget.style.transform = transform
+    }
+
+    if (this.hasEditImageTarget && !document.getElementById("hex-edit-view").classList.contains("hidden")) {
+      this.editImageTarget.style.transform = transform
+    }
+
+    // Notify hex-editor controller with detailed transform data
+    this.dispatch('transformed', {
+      detail: {
+        transform: transform,
+        translateX: this.currentX,
+        translateY: this.currentY,
+        scale: this.scale
+      },
+      bubbles: true
+    })
+  }
+
+  resetView() {
+    this.currentX = 0
+    this.currentY = 0
+    this.scale = 1
+    this.updateTransform()
+  }
+}

--- a/app/javascript/controllers/maps_controller.js
+++ b/app/javascript/controllers/maps_controller.js
@@ -8,6 +8,9 @@ export default class extends Controller {
         event.preventDefault()
         const mapId = event.currentTarget.dataset.mapId
 
+        this.enableEditButton(mapId);
+        this.enablePlayButton(mapId);
+
         fetch(`/maps/${mapId}/preview`, {
             headers: { 'Accept': 'text/html' }
         })
@@ -16,4 +19,51 @@ export default class extends Controller {
             this.previewTarget.innerHTML = html
         })
     }
+
+    enableEditButton(mapID){
+        const editButton = document.querySelector('[data-id="edit-map"]')
+        if (editButton) {
+            editButton.href = `/maps/${mapID}/edit`
+            editButton.classList.remove('btn-disabled')
+        }
+    }
+
+    enablePlayButton(mapID){
+        const playButton = document.querySelector('[data-id="play-map"]')
+        if (playButton){
+            playButton.href = `/maps/${mapID}`
+            playButton.classList.remove('btn-disabled')
+        }
+    }
+
+    resetEditPanes(){
+        document.getElementById("map-info").classList.remove("hidden")
+        document.getElementById("controls").classList.add("hidden")
+        document.getElementById("hex-controls").classList.add("hidden")
+        document.getElementById("region-controls").classList.add("hidden")
+        document.getElementById("map-controls").classList.add("hidden")
+        document.getElementById("hex-flyout-section").classList.add("hidden")
+
+        document.getElementById("edit-map-button").classList.remove("hidden")
+        document.getElementById("manage-regions-button").classList.remove("hidden")
+        document.getElementById("hexes-edit-button").textContent = "Manage Hexes"
+        document.getElementById("region-container").classList.remove("hidden")
+
+        // Switch to hex editing view
+        document.getElementById("normal-map-view").classList.remove("hidden")
+        document.getElementById("hex-edit-view").classList.add("hidden")
+    }
+
+    showMapEditPane(){
+        document.getElementById("map-info").classList.add("hidden")
+        document.getElementById("controls").classList.remove("hidden")
+        document.getElementById("hex-controls").classList.add("hidden")
+        document.getElementById("region-controls").classList.add("hidden")
+        document.getElementById("map-controls").classList.remove("hidden")
+
+        // Switch to hex editing view
+        document.getElementById("normal-map-view").classList.add("hidden")
+        document.getElementById("hex-edit-view").classList.remove("hidden")
+    }
+
 }

--- a/app/javascript/controllers/region_controller.js
+++ b/app/javascript/controllers/region_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+
+    enableRegionEditPane(){
+        document.getElementById("map-info").classList.add("hidden")
+        document.getElementById("controls").classList.remove("hidden")
+        document.getElementById("hex-controls").classList.add("hidden")
+        document.getElementById("region-controls").classList.remove("hidden")
+        document.getElementById("map-controls").classList.add("hidden")
+
+        // Show regular map
+        document.getElementById("normal-map-view").classList.remove("hidden")
+        document.getElementById("hex-edit-view").classList.add("hidden")
+    }
+
+}

--- a/app/jobs/map_render_job.rb
+++ b/app/jobs/map_render_job.rb
@@ -1,0 +1,29 @@
+class MapRenderJob < ApplicationJob
+  queue_as :default
+
+  def perform(map_id)
+    map = Map.includes(:hexes, hexes: :region).find(map_id)
+
+    Rails.logger.info "Starting map render for Map #{map_id}"
+    start_time = Time.current
+
+    renderer = MapRenderer.new(map)
+    result = renderer.render_complete_map
+
+    if result
+      duration = Time.current - start_time
+      Rails.logger.info "Map #{map_id} rendered successfully in #{duration.round(2)}s: #{result}"
+
+      # No database changes needed - just log success
+      broadcast_map_update(map)
+    else
+      Rails.logger.error "Failed to render Map #{map_id}"
+    end
+  end
+
+  private
+
+  def broadcast_map_update(map)
+    Rails.logger.info "Would broadcast map update for Map #{map.id}"
+  end
+end

--- a/app/models/hex.rb
+++ b/app/models/hex.rb
@@ -5,6 +5,9 @@ class Hex < ApplicationRecord
   has_many :resources, through: :hex_resources
   has_many :notes, dependent: :destroy
 
+  validates :x_coordinate, :y_coordinate, presence: true
+  validates :x_coordinate, :y_coordinate, numericality: { greater_than_or_equal_to: 0 }
+
   def coordinates
     "#{x_coordinate}, #{y_coordinate}"
   end

--- a/app/services/map_renderer.rb
+++ b/app/services/map_renderer.rb
@@ -1,0 +1,197 @@
+class MapRenderer
+  require "chunky_png"
+
+  def initialize(map)
+    @map = map
+  end
+
+  def render_complete_map
+    # Get base map image dimensions
+    base_image = get_base_image
+    return nil unless base_image
+
+    # Create working image from base map
+    image = base_image.dup
+
+    # Draw all hexes grouped by region
+    draw_hexes_on_image(image)
+
+    # Save the rendered image
+    save_rendered_image(image)
+  end
+
+  private
+
+  def get_base_image
+    return nil unless @map.image.attached?
+
+    # Create a temporary file and download directly to it
+    temp_file = Tempfile.new([ "original_map", ".tmp" ])
+    temp_file.binmode
+
+    # Download blob data directly to temp file
+    @map.image.blob.download do |chunk|
+      temp_file.write(chunk)
+    end
+    temp_file.close
+
+    # Check if it's JPEG by reading the first few bytes
+    File.open(temp_file.path, "rb") do |file|
+      magic_bytes = file.read(2)
+      file.rewind
+
+      if magic_bytes == "\xFF\xD8".b  # JPEG magic bytes
+        Rails.logger.info "Detected JPEG image, converting to PNG"
+        convert_jpeg_to_png(temp_file.path)
+      else
+        Rails.logger.info "Assuming PNG image, loading directly"
+        ChunkyPNG::Image.from_file(temp_file.path)
+      end
+    end
+  ensure
+    temp_file&.unlink  # Clean up temp file
+  end
+
+  def is_jpeg?(data)
+    # Check for JPEG magic bytes at start of data
+    if data.is_a?(String)
+      data.force_encoding("BINARY").start_with?("\xFF\xD8".force_encoding("BINARY"))
+    else
+      # Reset position and read first 2 bytes
+      data.rewind if data.respond_to?(:rewind)
+      first_bytes = data.read(2)
+      data.rewind if data.respond_to?(:rewind)
+      first_bytes.force_encoding("BINARY") == "\xFF\xD8".force_encoding("BINARY")
+    end
+  end
+
+  def convert_jpeg_to_png(jpeg_file_path)
+    require "mini_magick"
+
+    # Convert JPEG file to PNG
+    image = MiniMagick::Image.open(jpeg_file_path)
+    temp_png = Tempfile.new([ "map_converted", ".png" ])
+    temp_png.close
+
+    image.format("png")
+    image.write(temp_png.path)
+
+    # Load the converted PNG with ChunkyPNG
+    result = ChunkyPNG::Image.from_file(temp_png.path)
+
+    # Cleanup
+    temp_png.unlink
+
+    result
+  rescue => e
+    Rails.logger.error "JPEG conversion failed: #{e.message}"
+    raise e
+  end
+
+  def draw_hexes_on_image(image)
+    # Group hexes by region for consistent coloring
+    @map.hexes.includes(:region).group_by(&:region).each do |region, hexes|
+      color = region_color(region)
+
+      hexes.each do |hex|
+        draw_hex(image, hex, color)
+      end
+    end
+  end
+
+  def draw_hex(image, hex, color)
+    # Use your actual positioning formula
+    center_x = (@map.hex_scale_x * 40 * hex.x_coordinate) + @map.offset_x
+    center_y = (@map.hex_scale_y * 40 * hex.y_coordinate) + @map.offset_y
+
+    # Use a fixed hex size (you can adjust this)
+    radius = 18  # This gives roughly 40px hex width
+
+    # Generate hexagon points
+    points = []
+    6.times do |i|
+      angle = (Math::PI / 3) * i
+      x = center_x + (radius * Math.cos(angle)).round
+      y = center_y + (radius * Math.sin(angle)).round
+      points << [ x, y ]
+    end
+
+    # Draw hexagon outline
+    draw_polygon_outline(image, points, color)
+  end
+
+  def draw_polygon_outline(image, points, color)
+    # Draw lines between consecutive points
+    points.each_with_index do |point, i|
+      next_point = points[(i + 1) % points.length]
+      draw_line(image, point[0], point[1], next_point[0], next_point[1], color)
+    end
+  end
+
+  def draw_line(image, x0, y0, x1, y1, color)
+    # Simple line drawing using Bresenham's algorithm
+    dx = (x1 - x0).abs
+    dy = (y1 - y0).abs
+    sx = x0 < x1 ? 1 : -1
+    sy = y0 < y1 ? 1 : -1
+    err = dx - dy
+
+    x, y = x0, y0
+
+    loop do
+      # Set pixel if within image bounds
+      if x >= 0 && x < image.width && y >= 0 && y < image.height
+        image[x, y] = color
+      end
+
+      break if x == x1 && y == y1
+
+      e2 = 2 * err
+      if e2 > -dy
+        err -= dy
+        x += sx
+      end
+      if e2 < dx
+        err += dx
+        y += sy
+      end
+    end
+  end
+
+  def region_color(region)
+    # Default colors - you can customize this based on your Region model
+    if region.nil?
+      ChunkyPNG::Color.rgb(128, 128, 128) # Gray for no region
+    else
+      # You can add a color field to your Region model, or use a hash lookup
+      case region.id % 6
+      when 0 then ChunkyPNG::Color.rgb(255, 0, 0)     # Red
+      when 1 then ChunkyPNG::Color.rgb(0, 255, 0)     # Green
+      when 2 then ChunkyPNG::Color.rgb(0, 0, 255)     # Blue
+      when 3 then ChunkyPNG::Color.rgb(255, 255, 0)   # Yellow
+      when 4 then ChunkyPNG::Color.rgb(255, 0, 255)   # Magenta
+      when 5 then ChunkyPNG::Color.rgb(0, 255, 255)   # Cyan
+      end
+    end
+  end
+
+  def save_rendered_image(image)
+    # Create public/maps directory if it doesn't exist
+    maps_dir = Rails.root.join("public", "maps")
+    FileUtils.mkdir_p(maps_dir)
+
+    # Save with version timestamp for cache busting
+    filename = "#{@map.id}_v#{@map.updated_at.to_i}.png"
+    filepath = maps_dir.join(filename)
+
+    image.save(filepath.to_s)
+
+    # Store the filename so we can reference it later
+    @rendered_filename = filename
+    filepath.to_s
+  end
+
+  def rendered_filename
+    @rendered_filename
+  end
+end

--- a/app/views/hexes/_hex_editor.html.erb
+++ b/app/views/hexes/_hex_editor.html.erb
@@ -1,0 +1,85 @@
+<div class="w-full h-full p-4">
+  <div class="w-full h-full bg-base-300 rounded overflow-hidden"
+       data-controller="hex-editor"
+       data-hex-editor-map-id-value="<%= map.id %>"
+       data-hex-editor-hex-scale-x-value="<%= map.hex_scale_x %>"
+       data-hex-editor-hex-scale-y-value="<%= map.hex_scale_y %>"
+       data-hex-editor-offset-x-value="<%= map.offset_x %>"
+       data-hex-editor-offset-y-value="<%= map.offset_y %>"
+       data-hex-editor-hexes-value="<%= map.hexes.to_json(only: [:id, :x_coordinate, :y_coordinate, :region_id]) %>">
+
+    <% if map.image.attached? %>
+      <div class="w-full h-full relative overflow-hidden cursor-grab"
+           data-hex-editor-target="container">
+
+        <!-- Show the original map image (not the rendered one) -->
+        <%= image_tag map.image,
+            alt: map.name,
+            data: {
+              hex_editor_target: "image",
+              action: "mousedown->hex-editor#startDrag wheel->hex-editor#handleZoom"
+            },
+            class: "absolute top-0 left-0 select-none transition-transform duration-100 ease-out" %>
+
+        <!-- SVG overlay for live hex drawing -->
+        <svg class="absolute top-0 left-0 w-full h-full pointer-events-none origin-top-left"
+             data-hex-editor-target="hexOverlay"
+             style="transform-origin: top left;">
+          <!-- Hexes will be drawn here by JavaScript -->
+        </svg>
+
+        <!-- Controls overlay -->
+        <div class="absolute top-4 left-4 bg-base-100 rounded p-2 shadow-lg space-y-2">
+          <div class="text-sm font-semibold">Hex Editor</div>
+
+          <div class="space-y-1">
+            <label class="text-xs">Scale X:</label>
+            <input type="number"
+                   step="0.1"
+                   data-hex-editor-target="scaleXInput"
+                   data-action="input->hex-editor#updateScale"
+                   value="<%= map.hex_scale_x %>"
+                   class="input input-xs w-16">
+          </div>
+
+          <div class="space-y-1">
+            <label class="text-xs">Scale Y:</label>
+            <input type="number"
+                   step="0.1"
+                   data-hex-editor-target="scaleYInput"
+                   data-action="input->hex-editor#updateScale"
+                   value="<%= map.hex_scale_y %>"
+                   class="input input-xs w-16">
+          </div>
+
+          <div class="space-y-1">
+            <label class="text-xs">Offset X:</label>
+            <input type="number"
+                   data-hex-editor-target="offsetXInput"
+                   data-action="input->hex-editor#updateOffset"
+                   value="<%= map.offset_x %>"
+                   class="input input-xs w-16">
+          </div>
+
+          <div class="space-y-1">
+            <label class="text-xs">Offset Y:</label>
+            <input type="number"
+                   data-hex-editor-target="offsetYInput"
+                   data-action="input->hex-editor#updateOffset"
+                   value="<%= map.offset_y %>"
+                   class="input input-xs w-16">
+          </div>
+
+          <button class="btn btn-primary btn-xs w-full"
+                  data-action="click->hex-editor#saveAndRender">
+            Save & Render Map
+          </button>
+        </div>
+      </div>
+    <% else %>
+      <div class="flex items-center justify-center h-full text-base-content/50">
+        <span>No map image available</span>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/maps/_map.html.erb
+++ b/app/views/maps/_map.html.erb
@@ -1,42 +1,69 @@
-<div id="<%= dom_id map %>">
+<div class="w-full h-full p-4">
+  <div class="w-full h-full bg-base-300 rounded overflow-hidden"
+       data-controller="map-play hex-editor"
+       data-map-play-map-id-value="<%= map.id %>"
+       data-hex-editor-hexes-value="<%= map.hexes.to_json(only: [:id, :x_coordinate, :y_coordinate, :region_id]) %>"
+       data-hex-editor-hex-scale-x-value="<%= map.hex_scale_x %>"
+       data-hex-editor-hex-scale-y-value="<%= map.hex_scale_y %>"
+       data-hex-editor-offset-x-value="<%= map.offset_x %>"
+       data-hex-editor-offset-y-value="<%= map.offset_y %>">
 
-  <p><%= notice %></p>
-
-  <p>
-    <strong>Name:</strong>
-    <%= map.name %>
-  </p>
-
-  <p>
-    <strong>Description:</strong>
-    <%= map.description %>
-  </p>
-
-  <p>
-    <strong>Regions:</strong>
-  </p>
-  <% if map.regions.any? %>
-    <ul>
-      <% map.regions.each do |region| %>
-        <li><%= region.name %></li>
-      <% end %>
-    </ul>
-  <% end %>
-  
-  <%= form_with model: [map, map.regions.build], local: true do |form| %>
-    <%= form.text_field :name, placeholder: "Region name" %>
-    <%= form.submit "Add Region" %>
-  <% end %>
-
-  <%= render "shared/card", variant: :map do %>
     <% if map.image.attached? %>
-      <%= image_tag map.image, alt: map.name, class: "#{spacing[:card][:thumbnail]} w-auto h-auto object-cover rounded" %>
+      <div class="w-full h-full relative overflow-hidden cursor-grab"
+           data-map-play-target="container">
+
+        <!-- Normal view: rendered image or fallback -->
+        <div id="normal-map-view">
+          <%
+            rendered_image_path = "/maps/#{map.id}_v#{map.updated_at.to_i}.png"
+            use_rendered = File.exist?(Rails.root.join('public', rendered_image_path.sub('/', '')))
+          %>
+
+          <% if use_rendered %>
+            <%= image_tag rendered_image_path,
+                alt: map.name,
+                data: {
+                  map_play_target: "normalImage",
+                  action: "mousedown->map-play#startDrag wheel->map-play#handleZoom"
+                },
+                class: "absolute top-0 left-0 select-none transition-transform duration-100 ease-out origin-top-left" %>
+          <% else %>
+            <%= image_tag map.image,
+                alt: map.name,
+                data: {
+                  map_play_target: "normalImage",
+                  action: "mousedown->map-play#startDrag wheel->map-play#handleZoom"
+                },
+                class: "absolute top-0 left-0 select-none transition-transform duration-100 ease-out origin-top-left" %>
+            <!-- Show message that rendered image isn't available -->
+            <div class="absolute top-4 left-4 bg-yellow-500 text-black p-2 rounded shadow-lg">
+              <div class="text-sm font-semibold">No rendered map available</div>
+              <div class="text-xs">Switch to hex edit mode to generate one</div>
+            </div>
+          <% end %>
+        </div>
+
+        <!-- Hex editing view: original image + SVG overlay (initially hidden) -->
+        <div id="hex-edit-view" class="hidden">
+          <%= image_tag map.image,
+              alt: map.name,
+              data: {
+                map_play_target: "editImage",
+                action: "mousedown->map-play#startDrag wheel->map-play#handleZoom"
+              },
+              class: "absolute top-0 left-0 select-none transition-transform duration-100 ease-out origin-top-left" %>
+
+          <!-- SVG overlay for live hex drawing -->
+          <svg class="absolute top-0 left-0 w-full h-full pointer-events-none"
+               data-hex-editor-target="hexOverlay"
+               style="transform-origin: top left;">
+          </svg>
+        </div>
+      </div>
     <% else %>
-      <!-- Show placeholder or nothing -->
-      <div class="btn">No image available</div>
+      <div class="flex items-center justify-center h-full text-base-content/50">
+        <span>No map image available</span>
+      </div>
     <% end %>
-  <% end %>
-  <% map.hexes.each do |hex| %>
-    <%= render 'hexes/hex', hex: hex %>
-  <% end %>
+  </div>
 </div>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -17,18 +17,18 @@
         </label>
 
         <!-- Add/Plus Icon -->
-        <%= link_to new_map_path, { data: { testid: "new-map" }, class:"btn btn-accent btn-circle" } do %>
+        <%= link_to new_map_path, data: { testid: "new-map" }, class:"btn btn-accent btn-circle" do %>
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="w-6 h-6 stroke-gray-900">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
           </svg>
         <% end %>
 
         <!-- Edit/Pencil Icon -->
-        <button class="btn btn-accent btn-circle">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="w-6 h-6 stroke-gray-900">
+        <%= link_to '#', data: { id: "edit-map" }, class:"btn btn-accent btn-circle btn-disabled" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="w-6 h-6 stroke-current">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"></path>
           </svg>
-        </button>
+        <% end %>
 
         <!-- Image/Gallery Icon -->
         <button class="btn btn-info btn-circle">
@@ -38,11 +38,11 @@
         </button>
 
         <!-- Play Icon -->
-        <button class="btn btn-secondary btn-circle">
+        <%= link_to '#' , data: {id: "play-map"}, class:"btn btn-secondary btn-circle btn-disabled" do %>
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="-2 -2 24 24" class="w-6 h-6 stroke-current">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M0,9.75A9.75,9.75,0,1,1,9.75,19.5,9.761,9.761,0,0,1,0,9.75Zm1.5,0A8.25,8.25,0,1,0,9.75,1.5,8.259,8.259,0,0,0,1.5,9.75Zm5.75-3.8,7,3.8-7,3.8Z"></path>
           </svg>
-        </button>
+        <% end %>
 
         <!-- Spacer -->
         <div class="flex-1"></div>
@@ -93,8 +93,8 @@
                           <p class="capitalize">
                             <strong> <%= map.name %> </strong>
                           </p>
-                          <p class="first-letter:uppercase italic line-clamp-4">
-                                 <%= map.description %>
+                          <p class="first-letter:uppercase italic">
+                            <%= map.description %>
                           </p>
                         </div>
                       </div>

--- a/app/views/maps/show.html.erb
+++ b/app/views/maps/show.html.erb
@@ -1,7 +1,277 @@
-<%= render @map %>
-<div>
-  <%= link_to "Edit this map", edit_map_path(@map) %> |
-  <%= link_to "Back to maps", maps_path %> |
-  <%= button_to "Update Hex Labels", update_hex_labels_map_path(@map), method: :patch %>
-  <%= button_to "Destroy this map", @map, method: :delete %>
+<div id="<%= dom_id @map %>" class="h-screen w-screen overflow-hidden flex flex-col" data-controller="maps regions hexes">
+
+  <!-- Map Info Header -->
+  <div id="header-section" class="bg-base-200 p-4 border-b border-base-300 h-24 overflow-hidden">
+    <div id="map-info">
+      <p><%= notice %></p>
+      <h1 class="text-2xl font-bold"><%= @map.name %></h1>
+      <p class="text-base-content/70 mt-1"><%= @map.description %></p>
+    </div>
+
+    <div id="controls" class="hidden h-full">
+      <div id="hex-controls" class="hidden h-full flex items-center">
+        <div class="flex flex-wrap items-center gap-4 w-full">
+
+          <!-- Position Controls -->
+          <div class="flex items-center gap-3">
+            <span class="text-sm font-semibold">Position:</span>
+            <div class="flex items-center gap-2">
+              <label class="text-xs font-medium text-gray-600">
+                X:
+                <input type="number" class="w-16 px-2 py-1 text-sm border border-gray-300 rounded" value="0" step="1">
+              </label>
+            </div>
+            <div class="flex items-center gap-2">
+              <label class="text-xs font-medium text-gray-600">
+                Y:
+                <input type="number" class="w-16 px-2 py-1 text-sm border border-gray-300 rounded" value="0" step="1">
+              </label>
+            </div>
+          </div>
+
+          <!-- Scale Controls -->
+          <div class="flex items-center gap-3">
+            <span class="text-sm font-semibold">Scale:</span>
+            <div class="flex items-center gap-2">
+              <label class="text-xs font-medium text-gray-600">
+                X:
+                <input type="number" class="w-16 px-2 py-1 text-sm border border-gray-300 rounded" value="1.0" step="0.1" min="0.1" max="5.0">
+              </label>
+            </div>
+            <div class="flex items-center gap-2 text-center">
+              <label class="text-xs font-medium text-gray-600">
+                Y:
+                <input type="number" class="w-16 px-2 py-1 text-sm border border-gray-300 rounded" value="1.0" step="0.1" min="0.1" max="5.0">
+              </label>
+            </div>
+          </div>
+
+          <!-- Orientation Control -->
+          <div class="flex items-center gap-3">
+            <span class="text-sm font-semibold">Orientation:</span>
+            <%= button_tag "⬢",
+                           id: "hex-style-switch",
+                           data:{
+                             action: "click->hexes#flipHexStyle",
+                             controller: "hexes"
+                           },
+                           class: "btn btn-primary text-4xl text-center"%>
+          </div>
+
+          <!-- Action buttons -->
+          <div class="flex items-center gap-2 ml-auto">
+            <button class="px-4 py-1 text-sm bg-blue-500 text-white border border-blue-500 rounded hover:bg-blue-600">
+              Apply
+            </button>
+            <button class="px-4 py-1 text-sm border border-gray-300 rounded bg-white hover:bg-gray-50">
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div id="region-controls" class="hidden h-full flex items-center">
+        <div class="flex flex-wrap items-center gap-4 w-full">
+
+          <!-- Region Management -->
+          <div class="flex items-center gap-3">
+            <span class="text-sm font-semibold">Regions:</span>
+            <button class="px-3 py-1 text-sm bg-green-500 text-white border border-green-500 rounded hover:bg-green-600">
+              Edit Labels
+            </button>
+          </div>
+
+          <!-- Selected Hex Actions -->
+          <div class="flex items-center gap-3">
+            <span class="text-sm font-semibold">Selected Hexes:</span>
+            <label>
+              <select class="px-2 py-1 text-sm border border-gray-300 rounded bg-white min-w-32">
+                <option value="">Choose Region...</option>
+                <option value="region1">Region 1</option>
+                <option value="region2">Region 2</option>
+              </select>
+            </label>
+            <button class="px-3 py-1 text-sm bg-blue-500 text-white border border-blue-500 rounded hover:bg-blue-600">
+              Assign
+            </button>
+            <button class="px-3 py-1 text-sm bg-red-500 text-white border border-red-500 rounded hover:bg-red-600">
+              Remove
+            </button>
+          </div>
+
+          <!-- Action buttons -->
+          <div class="flex items-center gap-2 ml-auto">
+            <button class="px-4 py-1 text-sm bg-blue-500 text-white border border-blue-500 rounded hover:bg-blue-600">
+              Apply
+            </button>
+            <button class="px-4 py-1 text-sm border border-gray-300 rounded bg-white hover:bg-gray-50">
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Map Controls -->
+      <div id="map-controls" class="hidden h-full flex items-center">
+        <div class="flex flex-wrap items-center gap-4 w-full">
+
+          <!-- Map Image Position Controls -->
+          <div class="flex items-center gap-3">
+            <span class="text-sm font-semibold">Map Image Position:</span>
+            <div class="flex items-center gap-2">
+              <label class="text-xs font-medium text-gray-600">
+                X:
+                <input type="number" class="w-16 px-2 py-1 text-sm border border-gray-300 rounded" value="0" step="1">
+              </label>
+            </div>
+            <div class="flex items-center gap-2">
+              <label class="text-xs font-medium text-gray-600">
+                Y:
+                <input type="number" class="w-16 px-2 py-1 text-sm border border-gray-300 rounded" value="0" step="1">
+              </label>
+            </div>
+          </div>
+
+          <!-- Scale Controls -->
+          <div class="flex items-center gap-3">
+            <span class="text-sm font-semibold">Hex Positions:</span>
+            <div class="flex items-center gap-2">
+              <label class="text-xs font-medium text-gray-600">
+                X:
+                <input type="number" class="w-16 px-2 py-1 text-sm border border-gray-300 rounded" value="1.0" step="0.1" min="0.1" max="5.0">
+              </label>
+            </div>
+            <div class="flex items-center gap-2">
+              <label class="text-xs font-medium text-gray-600">
+                Y:
+                <input type="number" class="w-16 px-2 py-1 text-sm border border-gray-300 rounded" value="1.0" step="0.1" min="0.1" max="5.0">
+              </label>
+            </div>
+          </div>
+
+          <!-- Orientation Control -->
+          <div class="flex items-center gap-3">
+            <span class="text-sm font-semibold">Orientation:</span>
+            <button class="px-3 py-1 text-sm border border-gray-300 rounded bg-white hover:bg-gray-50">
+              ⬡ Pointy Top
+            </button>
+          </div>
+
+          <!-- Action buttons -->
+          <div class="flex items-center gap-2 ml-auto">
+            <button class="px-4 py-1 text-sm bg-blue-500 text-white border border-blue-500 rounded hover:bg-blue-600">
+              Apply
+            </button>
+            <button class="px-4 py-1 text-sm border border-gray-300 rounded bg-white hover:bg-gray-50">
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- Main Map Container -->
+  <div class="flex-1 relative overflow-hidden">
+    <!-- Map takes full remaining space -->
+    <div class="w-full h-full bg-neutral">
+      <div class="w-full h-full">
+        <%= render @map %>
+      </div>
+    </div>
+
+    <!-- Flyout Tab Toggle -->
+    <div class="absolute left-0 top-1/2 transform -translate-y-1/2 z-10">
+      <label for="admin-drawer" aria-label="open sidebar" data-action="click->maps#resetEditPanes" class="btn btn-primary btn-sm rounded-l-none rounded-r-lg pl-2 pr-3 shadow-lg cursor-pointer">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="w-4 h-4 stroke-current">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+        </svg>
+      </label>
+    </div>
+
+    <!-- Drawer -->
+    <div class="drawer">
+      <input id="admin-drawer" type="checkbox" class="drawer-toggle"/>
+
+      <!-- Drawer Side Panel -->
+      <div class="drawer-side z-50">
+        <label for="admin-drawer" aria-label="close sidebar" class="drawer-overlay" ></label>
+        <div class="menu bg-base-200 min-h-full w-80 p-4">
+          <div class="flex justify-between items-center mb-4">
+            <h3 class="text-lg font-semibold">Map Details</h3>
+            <label for="admin-drawer" class="btn btn-ghost btn-sm">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+              </svg>
+            </label>
+          </div>
+
+          <div class="space-y-4">
+            <!-- Default Fly-out Window Contents -->
+            <%= button_tag "Manage Map",
+                           type: "button",
+                           id:"edit-map-button",
+                           data: {
+                             action: "click->maps#showMapEditPane",
+                             controller: "maps",
+                             map: @map
+                           },
+                           class:"btn btn-primary w-full" %>
+            <%= button_tag "Manage Regions",
+                           type:"button",
+                           id:"manage-regions-button",
+                           data: {
+                             action: "click->regions#enableRegionEditPane",
+                             controller: "regions"
+                           },
+                           class:"btn btn-success w-full" %>
+            <%= button_tag "Manage Hexes",
+                           type:"button",
+                           id:"hexes-edit-button",
+                           data: {
+                             action:"click->hexes#toggleHexFlyout",
+                             map: @map
+                           },
+                           class:"btn btn-secondary w-full" %>
+            <div id="region-container" class="border-t border-base-300 pt-4">
+              <h4 class="font-medium mb-2">Regions:</h4>
+              <% if @map.regions.any? %>
+                <ul class="space-y-1">
+                  <% @map.regions.each do |region| %>
+                    <li class="text-sm bg-base-300 px-2 py-1 rounded"><%= region.name %></li>
+                  <% end %>
+                </ul>
+              <% else %>
+                <p class="text-sm text-base-content/50">No regions added yet</p>
+              <% end %>
+            </div>
+
+            <!-- Hex Fly-out Window Contents - Initially Hidden -->
+            <div id="hex-flyout-section" class="space-y-4 hidden">
+              <div id="hex-divider-element" class="divider"></div>
+              <%= button_tag "Generate Hexes",
+                           type:"button",
+                           data:{
+                             id:"generate-hexes-button",
+                             action:"click->hexes#generateHexes",
+                             controller: "hexes",
+                             hexes_map_id_value: @map.id,
+                             hexes_hex_cols_value: 5,
+                             hexes_hex_rows_value: 2},
+                           class:"btn btn-primary w-full" %>
+              <%= button_tag "Edit Hexes",
+                             type:"button",
+                             data:{
+                               id:"edit-hexes-button",
+                               action:"click->hexes#enableHexEditPane",
+                               controller: "hexes"
+                             },
+                             class:"btn btn-secondary w-full"%>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,11 @@
 Rails.application.routes.draw do
   resources :maps do
     resources :regions, only: [ :create ]
-    resources :hexes, only: [ :update ]
+    resources :hexes, only: [ :update ] do
+      collection do
+        post "bulk_create"
+      end
+    end
     member do
       patch :update_hex_labels
       get :preview

--- a/db/migrate/20250701124719_change_hex_scale_to_xy_in_maps.rb
+++ b/db/migrate/20250701124719_change_hex_scale_to_xy_in_maps.rb
@@ -1,0 +1,7 @@
+class ChangeHexScaleToXyInMaps < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :maps, :hex_scale
+    add_column :maps, :hex_scale_x, :decimal
+    add_column :maps, :hex_scale_y, :decimal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_22_193725) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_01_124719) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -82,12 +82,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_22_193725) do
     t.datetime "updated_at", null: false
     t.integer "columns"
     t.integer "rows"
-    t.float "hex_scale"
     t.float "image_scale_horizontal"
     t.float "image_scale_vertical"
     t.integer "offset_x"
     t.integer "offset_y"
     t.string "description"
+    t.decimal "hex_scale_x"
+    t.decimal "hex_scale_y"
   end
 
   create_table "notes", force: :cascade do |t|


### PR DESCRIPTION
Changes:
1. Updated the detail view of the map - UI elements (some functional, some decorative) to manage the map, hexes, regions, and placement.
2. Added map zoom and scroll
3. Applied map zoom and scroll to hex overlays
4. Added functionality that will generate a PNG image of the map and its hexes, with cache busting naming convention.  TODO: Deliver to clients for faster map viewing / responsiveness
5. Added some dependencies that support PNG rendering and image file type conversion
6. Small update to the map schema - now have X and Y scales for hex, rather than a single scale value.  this will be useful later when we need to scale the size of hexes in X and Y direction differently
7. It is now possible to update hex orientation.  View map -> Manage Hexes -> Edit Hex -> click the icon at the to of the page to swap orientation