### PR TITLE
32 change map columns and rows regenerate hex grid

### DIFF
--- a/app/controllers/hexes_controller.rb
+++ b/app/controllers/hexes_controller.rb
@@ -11,6 +11,10 @@ class HexesController < ApplicationController
   end
 
   def bulk_create
+    # Delete hexes if the already exist
+    @map.hexes.destroy_all
+
+    # generate the hexes
     hex_params = params[:hexes]
     created_hexes = []
     hex_params.each do |hex_data|

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -80,6 +80,6 @@ class MapsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def map_params
-      params.expect(map: [ :name, :description, :image ])
+      params.expect(map: [ :name, :description, :image, :columns, :rows, :hex_radius ])
     end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,10 @@
 class PagesController < ApplicationController
+  allow_unauthenticated_access only: [ :index ]
   def index
-    # Landing page - no authentication required
+    # Redirect authenticated users to maps index
+    if authenticated?
+      redirect_to maps_path
+      nil
+    end
   end
 end

--- a/app/javascript/controllers/hex_controller.js
+++ b/app/javascript/controllers/hex_controller.js
@@ -11,6 +11,8 @@ export default class extends Controller {
     }
 
     connect(){
+        this.hexData = [];
+
         document.addEventListener('hexDimensionUpdate', (event) => this.regenerateHexes(event.detail));
         document.addEventListener('maps:hexDimensionUpdate', (event) => this.regenerateHexes(event.detail));
         document.addEventListener('hexRadiusUpdate', (event) => this.regenerateHexes(event.detail));
@@ -37,12 +39,12 @@ export default class extends Controller {
     }
 
     generateHexes() {
-        const hexData = [];
+        this.hexData = [];
 
         // Generate hex coordinates
         for (let col = 0; col < this.hexColsValue; col++) {
             for (let row = 0; row < this.hexRowsValue; row++) {
-                hexData.push({
+                this.hexData.push({
                     map_id: this.mapIdValue,
                     x_coordinate: col,
                     y_coordinate: row,
@@ -54,11 +56,9 @@ export default class extends Controller {
             }
         }
 
-        // TODO: move the comment below to be triggered by the "Save" button instead
-        // this.createHexesInDatabase(hexData);
         this.dispatch('regenerateHexes', {
             detail: {
-                hexes: hexData,
+                hexes: this.hexData,
                 radius: this.hexRadiusValue
             },
             bubbles: true,
@@ -66,7 +66,7 @@ export default class extends Controller {
         });
     }
 
-    async createHexesInDatabase(hexData) {
+    async createHexesInDatabase() {
         try {
             const response = await fetch(`/maps/${this.mapIdValue}/hexes/bulk_create`, {
                 method: 'POST',
@@ -74,7 +74,7 @@ export default class extends Controller {
                     'Content-Type': 'application/json',
                     'X-CSRF-Token': document.querySelector('[name="csrf-token"]').getAttribute('content')
                 },
-                body: JSON.stringify({ hexes: hexData })
+                body: JSON.stringify({ hexes: this.hexData })
             });
 
             if (response.ok) {

--- a/app/javascript/controllers/hex_controller.js
+++ b/app/javascript/controllers/hex_controller.js
@@ -6,16 +6,33 @@ export default class extends Controller {
     static values = {
         mapId: Number,
         hexCols: Number,
-        hexRows: Number
+        hexRows: Number,
+        hexRadius: Number
     }
 
     connect(){
         document.addEventListener('hexDimensionUpdate', (event) => this.regenerateHexes(event.detail));
+        document.addEventListener('maps:hexDimensionUpdate', (event) => this.regenerateHexes(event.detail));
+        document.addEventListener('hexRadiusUpdate', (event) => this.regenerateHexes(event.detail));
+        document.addEventListener('maps:hexRadiusUpdate', (event) => this.regenerateHexes(event.detail));
     }
 
     regenerateHexes(detail){
-        this.hexColsValue = detail.cols;
-        this.hexRowsValue = detail.rows;
+        if(detail.cols != null){
+            this.hexColsValue = detail.cols;
+        } else {
+            this.hexColsValue = parseInt(document.getElementById("map-col-control").value)
+        }
+        if(detail.rows != null){
+            this.hexRowsValue = detail.rows;
+        } else {
+            this.hexRowsValue = parseInt(document.getElementById("map-row-control").value)
+        }
+        if(detail.radius != null){
+            this.hexRadiusValue = detail.radius;
+        } else {
+            this.hexRadiusValue = (parseInt(document.getElementById("map-hex-radius-control").value) / 10)
+        }
         this.generateHexes();
     }
 
@@ -41,7 +58,8 @@ export default class extends Controller {
         // this.createHexesInDatabase(hexData);
         this.dispatch('regenerateHexes', {
             detail: {
-                hexes: hexData
+                hexes: hexData,
+                radius: this.hexRadiusValue
             },
             bubbles: true,
             cancelable: true

--- a/app/javascript/controllers/hex_editor_controller.js
+++ b/app/javascript/controllers/hex_editor_controller.js
@@ -26,7 +26,7 @@ export default class extends Controller {
     if(!this.maxRowsValue) this.maxRowsValue = 10;
     if(!this.mapWidthValue) this.mapWidthValue = 800;
     if(!this.mapHeightValue) this.mapHeightValue = 600;
-    if(!this.hexRadiusValue) this.hexRadiusValue = 50;
+    if(!this.hexRadiusValue) this.hexRadiusValue = 20;
     this.currentMapTranslateX = 0;
     this.currentMapTranslateY = 0;
     this.svgScaleX = 1;
@@ -42,8 +42,9 @@ export default class extends Controller {
     this.drawHexes(document.getElementById("hex-style-switch").textContent.charAt(0));
   }
 
-  redrawHexes(detail){
-    this.hexesValue = detail.hexes;
+  redrawHexes(hexes){
+    this.hexesValue = hexes.hexes;
+    this.hexRadiusValue = hexes.radius;
     this.drawHexes();
   }
 
@@ -66,7 +67,7 @@ export default class extends Controller {
 
     if (currentHexStyle === "⬣") { // Flat-top hexagon
       // For flat-top: width = 2 * radius, height = √3 * radius
-      hexHeight = Math.sqrt(3) * this.hexRadiusValue; // temp radius for calculation
+      hexHeight = Math.sqrt(3) * this.hexRadiusValue;
       hexWidth = 2 * this.hexRadiusValue;
 
       // Calculate spacing needed
@@ -75,7 +76,7 @@ export default class extends Controller {
 
     } else { // Pointy-top hexagon
       // For pointy-top: width = √3 * radius, height = 2 * radius
-      hexWidth = Math.sqrt(3) * this.hexRadiusValue; // temp radius for calculation
+      hexWidth = Math.sqrt(3) * this.hexRadiusValue;
       hexHeight = 2 * this.hexRadiusValue;
 
       // Calculate spacing needed

--- a/app/javascript/controllers/maps_controller.js
+++ b/app/javascript/controllers/maps_controller.js
@@ -4,6 +4,90 @@ export default class extends Controller {
 
     static targets = ["preview"];
 
+    connect(){
+        const sliderCols = document.getElementById('map-col-control');
+        const valueDisplayCols = document.getElementById('map-col-value');
+        const sliderRows = document.getElementById('map-row-control');
+        const valueDisplayRows = document.getElementById('map-row-value');
+        const sliderColsDec = document.getElementById("map-col-control-dec");
+        const sliderColsInc = document.getElementById("map-col-control-inc");
+        const sliderRowsDec = document.getElementById("map-row-control-dec");
+        const sliderRowsInc = document.getElementById("map-row-control-inc");
+
+        /**
+         * Columns Controls Section
+         */
+        sliderCols.addEventListener('input', function() {
+            valueDisplayCols.textContent = this.value;
+            const event = new CustomEvent('hexDimensionUpdate', {
+                detail: {
+                    cols: sliderCols.value,
+                    rows: sliderRows.value
+                },
+                bubbles: true,
+                cancelable: true
+            });
+            document.dispatchEvent(event);
+        });
+
+        /**
+         * Rows Controls Section
+         */
+        sliderRows.addEventListener('input', function() {
+            valueDisplayRows.textContent = this.value;
+            const event = new CustomEvent('hexDimensionUpdate', {
+                detail: {
+                    cols: sliderCols.value,
+                    rows: sliderRows.value
+                },
+                bubbles: true,
+                cancelable: true
+            });
+            document.dispatchEvent(event);
+        });
+    }
+
+    decrementCols(){
+        const colControl = document.getElementById('map-col-control');
+        const cols = parseInt(colControl.value);
+        if(cols > colControl.min){
+            colControl.value = cols - 1;
+            this.updateMapColValue(colControl.value);
+        }
+    }
+    incrementCols(){
+        const colControl = document.getElementById('map-col-control');
+        const cols = parseInt(colControl.value);
+        if(cols < colControl.max){
+            colControl.value = cols + 1;
+            this.updateMapColValue(colControl.value);
+        }
+    }
+    decrementRows(){
+        const rowControl = document.getElementById('map-row-control');
+        const rows = parseInt(rowControl.value);
+        if(rows > rowControl.min){
+            rowControl.value = rows - 1;
+            this.updateMapRowValue(rowControl.value);
+        }
+    }
+    incrementRows(){
+        const rowControl = document.getElementById('map-row-control');
+        const rows = parseInt(rowControl.value);
+        if(rows < rowControl.max){
+            rowControl.value = rows + 1;
+            this.updateMapRowValue(rowControl.value);
+        }
+    }
+
+    updateMapColValue(value) {
+        document.getElementById('map-col-value').textContent = value;
+    }
+
+    updateMapRowValue(value) {
+      document.getElementById('map-row-value').textContent = value;
+    }
+
     loadPreview(event){
         event.preventDefault()
         const mapId = event.currentTarget.dataset.mapId
@@ -52,6 +136,9 @@ export default class extends Controller {
         // Switch to hex editing view
         document.getElementById("normal-map-view").classList.remove("hidden")
         document.getElementById("hex-edit-view").classList.add("hidden")
+
+        // Close the fly-out window
+        document.getElementById("admin-drawer").ariaLabel = "close sidebar";
     }
 
     showMapEditPane(){
@@ -64,6 +151,9 @@ export default class extends Controller {
         // Switch to hex editing view
         document.getElementById("normal-map-view").classList.add("hidden")
         document.getElementById("hex-edit-view").classList.remove("hidden")
+
+        // Close the fly-out window
+        document.getElementById("admin-drawer").checked = false;
     }
 
     updateHexTransform(){
@@ -80,7 +170,7 @@ export default class extends Controller {
                 scaleY: scaleY
             },
             bubbles: true
-        })
+        });
     }
 
 }

--- a/app/javascript/controllers/maps_controller.js
+++ b/app/javascript/controllers/maps_controller.js
@@ -2,6 +2,9 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
 
+    static values = {
+        mapId: Number
+    }
     static targets = ["preview"];
 
     connect(){
@@ -229,4 +232,36 @@ export default class extends Controller {
         });
     }
 
+    async saveMap(){
+        // Get values from sliders
+        const columnCount = document.getElementById('map-col-control').value
+        const rowCount = document.getElementById('map-row-control').value
+        const hexRadius = document.getElementById('map-hex-radius-control').value / 10 // Need a better way to use this value instead of dividing it by 10 everywhere
+
+        const mapData = {
+            columns: columnCount,
+            rows: rowCount,
+            hex_radius: hexRadius
+        }
+
+        try{
+            const response = await fetch(`/maps/${this.mapIdValue}`, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                    'X-CSRF-Token': document.querySelector('[name="csrf-token"]').getAttribute('content')
+                },
+                body: JSON.stringify({ map: mapData })
+            });
+
+            if (response.ok) {
+                console.log('Map updated successfully');
+            } else {
+                console.error('Failed to update map');
+            }
+        }catch (e){
+            console.error('Error updating map:', e);
+        }
+    }
 }

--- a/app/javascript/controllers/maps_controller.js
+++ b/app/javascript/controllers/maps_controller.js
@@ -9,10 +9,8 @@ export default class extends Controller {
         const valueDisplayCols = document.getElementById('map-col-value');
         const sliderRows = document.getElementById('map-row-control');
         const valueDisplayRows = document.getElementById('map-row-value');
-        const sliderColsDec = document.getElementById("map-col-control-dec");
-        const sliderColsInc = document.getElementById("map-col-control-inc");
-        const sliderRowsDec = document.getElementById("map-row-control-dec");
-        const sliderRowsInc = document.getElementById("map-row-control-inc");
+        const radiusSize = document.getElementById("map-hex-radius-control");
+        const radiusDisplay = document.getElementById("map-hex-radius-value");
 
         /**
          * Columns Controls Section
@@ -39,6 +37,21 @@ export default class extends Controller {
                 detail: {
                     cols: sliderCols.value,
                     rows: sliderRows.value
+                },
+                bubbles: true,
+                cancelable: true
+            });
+            document.dispatchEvent(event);
+        });
+
+        /**
+         * Radius Control Section
+         */
+        radiusSize.addEventListener('input', function() {
+            radiusDisplay.textContent = this.value;
+            const event = new CustomEvent('hexRadiusUpdate', {
+                detail: {
+                    radius: (radiusSize.value / 10)
                 },
                 bubbles: true,
                 cancelable: true
@@ -79,13 +92,51 @@ export default class extends Controller {
             this.updateMapRowValue(rowControl.value);
         }
     }
+    decrementHexRadius(){
+        const radiusControl = document.getElementById("map-hex-radius-control");
+        const radius = parseInt(radiusControl.value);
+        if(radius > radiusControl.min){
+            radiusControl.value = radius - 1;
+            this.updateHexRadius(radiusControl.value);
+        }
+    }
+    incrementHexRadius(){
+        const radiusControl = document.getElementById("map-hex-radius-control");
+        const radius = parseInt(radiusControl.value);
+        if(radius < radiusControl.max){
+            radiusControl.value = radius + 1;
+            this.updateHexRadius(radiusControl.value);
+        }
+    }
+
+    updateHexRadius(value){
+        document.getElementById("map-hex-radius-value").textContent = value;
+        this.dispatch("hexRadiusUpdate", {
+            detail:{
+                radius: parseInt(value) / 10
+            },
+            bubbles: true
+        });
+    }
 
     updateMapColValue(value) {
         document.getElementById('map-col-value').textContent = value;
+        this.dispatch("hexDimensionUpdate", {
+            detail:{
+                cols: parseInt(value)
+            },
+            bubbles: true
+        });
     }
 
     updateMapRowValue(value) {
       document.getElementById('map-row-value').textContent = value;
+      this.dispatch("hexDimensionUpdate", {
+            detail:{
+                rows: parseInt(value)
+            },
+            bubbles: true
+        });
     }
 
     loadPreview(event){
@@ -154,6 +205,11 @@ export default class extends Controller {
 
         // Close the fly-out window
         document.getElementById("admin-drawer").checked = false;
+
+        // Dispatch event to show the hex map
+        this.dispatch("hexDimensionUpdate", {
+            bubbles: true
+        });
     }
 
     updateHexTransform(){

--- a/app/javascript/controllers/region_controller.js
+++ b/app/javascript/controllers/region_controller.js
@@ -12,6 +12,9 @@ export default class extends Controller {
         // Show regular map
         document.getElementById("normal-map-view").classList.remove("hidden")
         document.getElementById("hex-edit-view").classList.add("hidden")
+
+        // Hide fly-out window
+        document.getElementById("admin-drawer").checked = false;
     }
 
 }

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -7,40 +7,50 @@
     <input id="admin-drawer" type="checkbox" class="drawer-toggle" />
     <div class="drawer-content flex flex-row h-screen">
       <!-- Vertical Sidebar -->
-      <div class="bg-base-100 w-16 flex flex-col items-center space-y-6">
+      <div class="bg-base-100 w-16 flex flex-col items-center space-y-6 pt-4">
 
         <!-- Hamburger Menu -->
         <label for="admin-drawer" aria-label="open sidebar" data-testid="hamburger-menu" class="btn btn-square btn-ghost">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="w-6 h-6 stroke-current">
-            <path color="white" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+            <path color="white"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M4 6h16M4 12h16M4 18h16"
+            />
           </svg>
         </label>
 
         <!-- Add/Plus Icon -->
         <%= link_to new_map_path, data: { testid: "new-map" }, class:"btn btn-accent btn-circle" do %>
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="w-6 h-6 stroke-gray-900">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+            <path stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M12 4v16m8-8H4"
+            />
           </svg>
         <% end %>
 
         <!-- Edit/Pencil Icon -->
-        <%= link_to '#', data: { id: "edit-map" }, class:"btn btn-accent btn-circle btn-disabled" do %>
+        <%= link_to '#', data: { id: "edit-map" }, class:"btn btn-primary btn-circle btn-disabled" do %>
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="w-6 h-6 stroke-current">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"></path>
+            <path stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+            />
           </svg>
         <% end %>
-
-        <!-- Image/Gallery Icon -->
-        <button class="btn btn-info btn-circle">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="w-6 h-6 stroke-current">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
-          </svg>
-        </button>
 
         <!-- Play Icon -->
         <%= link_to '#' , data: {id: "play-map"}, class:"btn btn-secondary btn-circle btn-disabled" do %>
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="-2 -2 24 24" class="w-6 h-6 stroke-current">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M0,9.75A9.75,9.75,0,1,1,9.75,19.5,9.761,9.761,0,0,1,0,9.75Zm1.5,0A8.25,8.25,0,1,0,9.75,1.5,8.259,8.259,0,0,0,1.5,9.75Zm5.75-3.8,7,3.8-7,3.8Z"></path>
+            <path stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M0,9.75A9.75,9.75,0,1,1,9.75,19.5,9.761,9.761,0,0,1,0,9.75Zm1.5,0A8.25,8.25,0,1,0,9.75,1.5,8.259,8.259,0,0,0,1.5,9.75Zm5.75-3.8,7,3.8-7,3.8Z"
+            />
           </svg>
         <% end %>
 

--- a/app/views/maps/show.html.erb
+++ b/app/views/maps/show.html.erb
@@ -232,7 +232,13 @@
                     <button class="btn btn-neutral">Cancel</button>
                   </form>
                   <!-- Your Rails button_to would go here -->
-                  <button class="btn btn-error">Delete Map</button>
+                  <%= button_to "Delete Map",
+                    map_path(@map),
+                    method: :delete,
+                    data: {
+                      testid: "delete-map-button-map"
+                    },
+                    class: "btn btn-error" %>
                 </div>
               </div>
             </dialog>

--- a/app/views/maps/show.html.erb
+++ b/app/views/maps/show.html.erb
@@ -1,4 +1,10 @@
-<div id="<%= dom_id @map %>" class="h-screen w-screen overflow-hidden flex flex-col" data-controller="maps regions hexes" data-testid="map-details-partial-DOM">
+<div id="<%= dom_id @map %>"
+     class="h-screen w-screen overflow-hidden flex flex-col"
+     data-controller="maps regions hexes"
+     data-testid="map-details-partial-DOM"
+     data-hexes-map-id-value="<%= @map.id %>"
+     data-maps-map-id-value="<%= @map.id %>"
+>
 
   <!-- Map Info Header -->
   <div id="header-section" class="bg-base-200 p-4 border-b border-base-300 h-24">
@@ -229,9 +235,15 @@
 
           <!-- Action buttons -->
           <div class="flex items-center gap-2 ml-auto">
-            <button class="btn btn-primary">
+            <%= link_to "#",
+                        class:"btn btn-primary",
+                        data: {
+                          action: "click->hexes#createHexesInDatabase click->maps#saveMap",
+                          detail: @map
+                        } do
+            %>
               Save
-            </button>
+            <% end %>
             <button class="btn btn-neutral" data-action="click->maps#resetEditPanes">
               Cancel
             </button>

--- a/app/views/maps/show.html.erb
+++ b/app/views/maps/show.html.erb
@@ -192,11 +192,11 @@
           <div class="form-control">
             <label for="map-col-control" id="map-col-view" class="label">
               <span class="label-text">Map Columns</span>
-              <span id="map-col-value" class="label-text-alt">20</span>
+              <span id="map-col-value" class="label-text-alt">4</span>
             </label>
             <div class="flex items-center gap-2">
               <button id="map-col-control-dec" class="btn btn-sm btn-outline btn-primary" data-action="click->maps#decrementCols">-</button>
-              <input id="map-col-control" type="range" min="0" max="100" value="20" class="range range-primary"/>
+              <input id="map-col-control" type="range" min="0" max="60" value="4" class="range range-primary" autocomplete="off"/>
               <button id="map-col-control-inc" class="btn btn-sm btn-outline btn-primary" data-action="click->maps#incrementCols">+</button>
             </div>
           </div>
@@ -205,12 +205,25 @@
           <div class="form-control">
             <label for="map-row-control" id="map-row-view" class="label">
               <span class="label-text">Map Rows</span>
-              <span id="map-row-value" class="label-text-alt">20</span>
+              <span id="map-row-value" class="label-text-alt">3</span>
             </label>
             <div class="flex items-center gap-2">
               <button id="map-row-control-dec" class="btn btn-sm btn-outline btn-primary" data-action="click->maps#decrementRows">-</button>
-              <input id="map-row-control" type="range" min="0" max="100" value="20" class="range range-primary"/>
+              <input id="map-row-control" type="range" min="0" max="45" value="3" class="range range-primary" autocomplete="off"/>
               <button id="map-row-control-inc" class="btn btn-sm btn-outline btn-primary" data-action="click->maps#incrementRows">+</button>
+            </div>
+          </div>
+
+          <!-- Hex Size -->
+          <div>
+            <label for="map-hex-radius-control" id="map-hex-radius-view" class="label">
+              <span class="label-text">Hex Size</span>
+              <span id="map-hex-radius-value" class="label-text-alt">200</span>
+            </label>
+            <div class="flex items-center gap-2">
+              <button id="map-hex-radius-control-dec" class="btn btn-sm btn-outline btn-primary" data-action="click->maps#decrementHexRadius">-</button>
+              <input id="map-hex-radius-control" type="range" min="1" max="1200" value="200" class="range range-neutral" autocomplete="off"/>
+              <button id="map-hex-radius-control-inc" class="btn btn-sm btn-outline btn-primary" data-action="click->maps#incrementHexRadius">+</button>
             </div>
           </div>
 

--- a/app/views/maps/show.html.erb
+++ b/app/views/maps/show.html.erb
@@ -86,15 +86,16 @@
                              action: "click->hexes#flipHexStyle",
                              controller: "hexes"
                            },
-                           class: "btn btn-primary text-4xl text-center"%>
+                           class: "btn btn-neutral text-4xl text-center"
+            %>
           </div>
 
           <!-- Action buttons -->
           <div class="flex items-center gap-2 ml-auto">
             <button class="btn btn-primary">
-              Apply
+              Save
             </button>
-            <button class="btn btn-neutral">
+            <button class="btn btn-neutral" data-action="click->maps#resetEditPanes">
               Cancel
             </button>
             <div class="divider divider-horizontal"></div>
@@ -127,7 +128,7 @@
           <!-- Region Management -->
           <div class="flex items-center gap-3">
             <span class="text-sm font-semibold">Regions:</span>
-            <button class="btn btn-secondary">
+            <button class="btn btn-outline">
               Edit Labels
             </button>
           </div>
@@ -135,7 +136,7 @@
           <!-- Selected Hex Actions -->
           <div class="flex items-center gap-3">
             <details class="dropdown">
-              <summary class="btn m-1">Manage Region</summary>
+              <summary class="btn btn-outline">Manage Region</summary>
               <ul class="menu dropdown-content bg-base-100 rounded-box z-50 w-52 p-2 shadow-sm">
                 <li><a>Region 1</a></li>
                 <li><a>Region 2</a></li>
@@ -144,7 +145,7 @@
                 <li><a>Region 5</a></li>
               </ul>
             </details>
-            <button class="btn btn-warning">
+            <button class="btn btn-accent">
               Assign
             </button>
             <button class="btn btn-error">
@@ -155,9 +156,9 @@
           <!-- Action buttons -->
           <div class="flex items-center gap-2 ml-auto">
             <button class="btn btn-primary">
-              Apply
+              Save
             </button>
-            <button class="btn btn-neutral">
+            <button class="btn btn-neutral" data-action="click->maps#resetEditPanes">
               Cancel
             </button>
             <div class="divider divider-horizontal"></div>
@@ -187,54 +188,38 @@
       <div id="map-controls" class="hidden h-full flex items-center">
         <div class="flex flex-wrap items-center gap-4 w-full">
 
-          <!-- Map Image Position Controls -->
-          <div class="flex items-center gap-3">
-            <span class="text-sm font-semibold">Map Image Position:</span>
+          <!-- Columns -->
+          <div class="form-control">
+            <label for="map-col-control" id="map-col-view" class="label">
+              <span class="label-text">Map Columns</span>
+              <span id="map-col-value" class="label-text-alt">20</span>
+            </label>
             <div class="flex items-center gap-2">
-              <label class="text-xs font-medium text-gray-600">
-                X:
-                <input type="number" class="w-16 px-2 py-1 text-sm border border-gray-300 rounded" value="0" step="1">
-              </label>
-            </div>
-            <div class="flex items-center gap-2">
-              <label class="text-xs font-medium text-gray-600">
-                Y:
-                <input type="number" class="w-16 px-2 py-1 text-sm border border-gray-300 rounded" value="0" step="1">
-              </label>
+              <button id="map-col-control-dec" class="btn btn-sm btn-outline btn-primary" data-action="click->maps#decrementCols">-</button>
+              <input id="map-col-control" type="range" min="0" max="100" value="20" class="range range-primary"/>
+              <button id="map-col-control-inc" class="btn btn-sm btn-outline btn-primary" data-action="click->maps#incrementCols">+</button>
             </div>
           </div>
 
-          <!-- Scale Controls -->
-          <div class="flex items-center gap-3">
-            <span class="text-sm font-semibold">Hex Positions:</span>
+          <!-- Rows -->
+          <div class="form-control">
+            <label for="map-row-control" id="map-row-view" class="label">
+              <span class="label-text">Map Rows</span>
+              <span id="map-row-value" class="label-text-alt">20</span>
+            </label>
             <div class="flex items-center gap-2">
-              <label class="text-xs font-medium text-gray-600">
-                X:
-                <input type="number" class="w-16 px-2 py-1 text-sm border border-gray-300 rounded" value="1.0" step="0.1" min="0.1" max="5.0">
-              </label>
+              <button id="map-row-control-dec" class="btn btn-sm btn-outline btn-primary" data-action="click->maps#decrementRows">-</button>
+              <input id="map-row-control" type="range" min="0" max="100" value="20" class="range range-primary"/>
+              <button id="map-row-control-inc" class="btn btn-sm btn-outline btn-primary" data-action="click->maps#incrementRows">+</button>
             </div>
-            <div class="flex items-center gap-2">
-              <label class="text-xs font-medium text-gray-600">
-                Y:
-                <input type="number" class="w-16 px-2 py-1 text-sm border border-gray-300 rounded" value="1.0" step="0.1" min="0.1" max="5.0">
-              </label>
-            </div>
-          </div>
-
-          <!-- Orientation Control -->
-          <div class="flex items-center gap-3">
-            <span class="text-sm font-semibold">Orientation:</span>
-            <button class="px-3 py-1 text-sm border border-gray-300 rounded bg-white hover:bg-gray-50">
-              ⬡ Pointy Top
-            </button>
           </div>
 
           <!-- Action buttons -->
           <div class="flex items-center gap-2 ml-auto">
             <button class="btn btn-primary">
-              Apply
+              Save
             </button>
-            <button class="btn btn-neutral">
+            <button class="btn btn-neutral" data-action="click->maps#resetEditPanes">
               Cancel
             </button>
             <div class="divider divider-horizontal"></div>
@@ -246,20 +231,14 @@
                   <form method="dialog">
                     <button class="btn btn-neutral">Cancel</button>
                   </form>
-                  <%= button_to "Delete Map",
-                    map_path(@map),
-                    method: :delete,
-                    data: {
-                      testid: "delete-map-button"
-                    },
-                    class: "btn btn-error" %>
+                  <!-- Your Rails button_to would go here -->
+                  <button class="btn btn-error">Delete Map</button>
                 </div>
               </div>
             </dialog>
           </div>
         </div>
       </div>
-
     </div>
   </div>
 
@@ -274,7 +253,7 @@
 
     <!-- Flyout Tab Toggle -->
     <div class="absolute left-0 top-1/2 transform -translate-y-1/2 z-10">
-      <label for="admin-drawer" id="flyout-tab-toggle" aria-label="open sidebar" data-action="click->maps#resetEditPanes" class="btn btn-primary btn-sm rounded-l-none rounded-r-lg pl-2 pr-3 shadow-lg cursor-pointer">
+      <label for="admin-drawer" id="flyout-tab-toggle" aria-label="open sidebar" class="btn btn-primary btn-sm rounded-l-none rounded-r-lg pl-2 pr-3 shadow-lg cursor-pointer">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="w-4 h-4 stroke-current">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
         </svg>
@@ -291,7 +270,7 @@
         <div class="menu bg-base-200 h-screen w-80 p-4 flex flex-col">
           <!-- Top section with close button aligned to the right -->
           <div class="flex justify-end mb-4">
-            <label id="fly-out-close-button" for="admin-drawer" class="btn btn-ghost btn-sm">
+            <label id="fly-out-close-button" for="admin-drawer" class="btn btn-ghost btn-sm" data-action="click->maps#resetEditPanes">
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
               </svg>
@@ -309,7 +288,8 @@
                              controller: "maps",
                              map: @map
                            },
-                           class:"btn btn-primary w-full" %>
+                           class:"btn btn-primary w-full"
+            %>
             <%= button_tag "Manage Regions",
                            type:"button",
                            id:"manage-regions-button",
@@ -317,7 +297,8 @@
                              action: "click->regions#enableRegionEditPane",
                              controller: "regions"
                            },
-                           class:"btn btn-success w-full" %>
+                           class:"btn btn-success w-full"
+            %>
             <%= button_tag "Manage Hexes",
                            type:"button",
                            id:"hexes-edit-button",
@@ -325,7 +306,8 @@
                              action:"click->hexes#toggleHexFlyout",
                              map: @map
                            },
-                           class:"btn btn-secondary w-full" %>
+                           class:"btn btn-secondary w-full"
+            %>
             <div id="region-container" class="border-t border-base-300 pt-4">
               <h4 class="font-medium mb-2">Regions:</h4>
               <% if @map.regions.any? %>
@@ -346,12 +328,13 @@
                              type:"button",
                              data:{
                                id:"generate-hexes-button",
-                               action:"click->hexes#generateHexes",
+                               action:"click->hexes#generateHexes click->hexes#enableHexEditPane",
                                controller: "hexes",
                                hexes_map_id_value: @map.id,
                                hexes_hex_cols_value: 5,
                                hexes_hex_rows_value: 2},
-                             class:"btn btn-primary w-full" %>
+                             class:"btn btn-primary w-full"
+              %>
               <%= button_tag "Edit Hexes",
                              type:"button",
                              data:{
@@ -359,7 +342,8 @@
                                action:"click->hexes#enableHexEditPane",
                                controller: "hexes"
                              },
-                             class:"btn btn-secondary w-full"%>
+                             class:"btn btn-secondary w-full"
+              %>
             </div>
           </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     resources :hexes, only: [ :update ] do
       collection do
         post "bulk_create"
+        post "bulk_replace"
       end
     end
     member do

--- a/db/migrate/20250705152515_add_hex_radius_to_maps.rb
+++ b/db/migrate/20250705152515_add_hex_radius_to_maps.rb
@@ -1,0 +1,5 @@
+class AddHexRadiusToMaps < ActiveRecord::Migration[8.0]
+  def change
+    add_column :maps, :hex_radius, :decimal, precision: 8, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_01_124719) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_05_152515) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -89,6 +89,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_01_124719) do
     t.string "description"
     t.decimal "hex_scale_x"
     t.decimal "hex_scale_y"
+    t.decimal "hex_radius", precision: 8, scale: 2
   end
 
   create_table "notes", force: :cascade do |t|

--- a/test/system/maps_test.rb
+++ b/test/system/maps_test.rb
@@ -133,16 +133,14 @@ class MapsTest < ApplicationSystemTestCase
     # Edit the Map
     find("#edit-map-button").click
 
-    # Close fly-out
-    find("#fly-out-close-button").click
-
     # Find and click the delete button
-    assert_selector "#delete_map_button_map", wait: 20
+    assert_selector "[data-controller='maps']", wait: 5
+    assert_selector "#delete_map_button_map", wait: 5
     find("#delete_map_button_map").click
 
     # Find and click the confirmation button in the modal pop-up
-    assert_selector "[data-testid='delete-map-button']", wait: 20
-    find("[data-testid='delete-map-button']").click
+    assert_selector "[data-testid='delete-map-button-map']", wait: 20
+    find("[data-testid='delete-map-button-map']").click
 
     # Wait for redirect to maps index
     assert_selector "[data-testid='index-DOM-div']", wait: 20


### PR DESCRIPTION
## Major Improvements!

* Added col, row, and hex radius options under Map Edit controls
* Hexes appear as soon as map is edited (Map Edit mode or Hex Edit mode)
* Map details (Columns, Rows, and Hex Radius) as well as the Hex Grid itself all save to the database when clicking "Save" from the Map Details view.

### Tweaks and QoL

* Removed the "Edit Image" option on the Maps index - this can be accomplished by editing the map details.
* Cleaned up some of the test cases that broke in a recent update
* Removed the logic that would always write hex data to DB - now properly deletes existing hex data before mass-creating hex data for a map